### PR TITLE
단건 조회 추가(+조회수 옵션), 부분 수정, 파일 없는 저장, 기본값 설정, 소프트 삭제

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ application.properties
 
 ### VS Code ###
 .vscode/
+
+# macOS Finder artifacts
+.DS_Store
+**/.DS_Store

--- a/src/main/java/com/hyend/pingu/controller/PostController.java
+++ b/src/main/java/com/hyend/pingu/controller/PostController.java
@@ -50,4 +50,13 @@ public class PostController {
 
         return ResponseEntity.ok(deletedPostId);
     }
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<PostResponseDTO> getPost(@PathVariable Long postId,
+                                                   @RequestParam(defaultValue = "true") boolean count) {
+    
+        PostResponseDTO postResponseDTO = postService.getPost(postId, count);
+    
+        return ResponseEntity.ok(postResponseDTO);
+    }
 }

--- a/src/main/java/com/hyend/pingu/dto/PostRequestDTO.java
+++ b/src/main/java/com/hyend/pingu/dto/PostRequestDTO.java
@@ -1,13 +1,16 @@
 package com.hyend.pingu.dto;
 
-import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 @Getter
-@Builder
+@Setter
+@NoArgsConstructor
 public class PostRequestDTO {
 
     private Long postId;

--- a/src/main/java/com/hyend/pingu/entity/Post.java
+++ b/src/main/java/com/hyend/pingu/entity/Post.java
@@ -39,6 +39,7 @@ public class Post extends BaseEntity{
     private Scope scope;
 
     @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<File> files = new ArrayList<>();
 
     public void changeTitle(String title) {
@@ -60,5 +61,18 @@ public class Post extends BaseEntity{
             this.files.add(file);
         });
     }
+
+    public void changeLatitude(float latitude) {
+        this.latitude = latitude;
+    }
+    
+    public void changeLongitude(float longitude) {
+        this.longitude = longitude;
+    }
+
+    public void increaseViewCount() {
+        this.viewCount++;
+    }
+    
 
 }

--- a/src/main/java/com/hyend/pingu/mapper/FileMapper.java
+++ b/src/main/java/com/hyend/pingu/mapper/FileMapper.java
@@ -13,7 +13,7 @@ public class FileMapper {
 
         String uriString = ServletUriComponentsBuilder
                 .fromCurrentContextPath()
-                .path("/files")
+                .path("/files/")
                 .path(file.getId().toString())
                 .toUriString();
 

--- a/src/main/java/com/hyend/pingu/mapper/PostMapper.java
+++ b/src/main/java/com/hyend/pingu/mapper/PostMapper.java
@@ -23,15 +23,20 @@ public class PostMapper {
                 .id(postRequestDTO.getUserId())
                 .build();
 
+        float lat = postRequestDTO.getLatitude() == null ? 0 : postRequestDTO.getLatitude();
+        float lon = postRequestDTO.getLongitude() == null ? 0 : postRequestDTO.getLongitude();
+        Scope scope = postRequestDTO.getScope() == null ? Scope.PUBLIC : Scope.valueOf(postRequestDTO.getScope());
+        
+
         Post post = Post.builder()
                 .user(user)
                 .title(postRequestDTO.getTitle())
                 .content(postRequestDTO.getContent())
                 .likeCount(0)
                 .viewCount(0)
-                .latitude(postRequestDTO.getLatitude())
-                .longitude(postRequestDTO.getLongitude())
-                .scope(Scope.valueOf(postRequestDTO.getScope()))
+                .latitude(lat)
+                .longitude(lon)
+                .scope(scope)
                 .build();
 
         return post;

--- a/src/main/java/com/hyend/pingu/service/PostService.java
+++ b/src/main/java/com/hyend/pingu/service/PostService.java
@@ -17,4 +17,11 @@ public interface PostService {
     Long modify(PostRequestDTO postRequestDTO) throws IOException;
 
     Long delete(Long postId);
+
+    default PostResponseDTO getPost(Long postId) {
+        return getPost(postId, true);
+    }
+    
+    PostResponseDTO getPost(Long postId, boolean count);
+
 }


### PR DESCRIPTION
- GET /posts/{postId}?count=... 추가
  - 기본(count=true) 시 조회수 +1, count=false면 증가 안 함
- 게시글 수정: title/content/scope/latitude/longitude 값 중 일부분 수정 시 다른 부분은 유지
- 파일 없더라도 게시글 저장 가능
- PostMapper: latitude/longitude 기본 0, scope 기본 PUBLIC 설정
- 삭제 시 물리 삭제 대신 Scope.DELETED로 소프트 삭제 후 저장